### PR TITLE
Reconfigure to work with scicomp infrastructure

### DIFF
--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -33,6 +33,9 @@ RUN chmod +x /get-experiments-from-samples.sh
 COPY concatenate-csvs.py /concatenate-csvs.py
 RUN chmod +x /concatenate-csvs.py
 
+COPY concatenate-csvs.py /get-column.py
+RUN chmod +x /get-column.py
+
 COPY manifest_types_short.txt /manifest_types_short.txt
 COPY manifest_types.txt /manifest_types.txt
 COPY collection_ids.txt /collection_ids.txt

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This Docker container is provided to run as an AWS Batch job. Each is an AWS Bat
 1. [run-live-manifests.sh](run-live-manifests.sh) gets the live data. It uses the [`manifest_types.txt`](manifest_types.txt) file to create the array jobs - one for each manifest type.
 1. [run-original-manifests.sh](run-original-manifests.sh) gets the historical (originally submitted) data. It uses the [`manifest_types_short.txt`](manifest_types_short.txt) file to create the array jobs - one for each manifest type.
 
+These tasks require access to the AWS Parameter store, in which the contents of the `ndaconfig.json` and Synapse configuration file are required to be stored. They must be stored in parameters named `/bsmn-ndasynapse-manifests/synapseConfig` and `/bsmn-ndasynapse-manifests/ndaConfig`.
+
 There are also two example AWS Batch job definition templates ([ndamanifests-live-array-job.json](ndamanifests-live-array-job.json) and [ndamanifests-original-array-job.json](ndamanifests-original-array-job.json) that can be used to submit directly to a configured job queue using the AWS command line interface:
 
 ```

--- a/get-experiments-from-samples.sh
+++ b/get-experiments-from-samples.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Get credentials for Synapse and NDA
-aws ssm get-parameters --names synapseconfig-kdaily --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/.synapseConfig
-aws ssm get-parameters --names nda-config --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/ndaconfig.json
+aws ssm get-parameters --names /bsmn-ndasynapse-manifests/synapseConfig --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/.synapseConfig
+aws ssm get-parameters --names /bsmn-ndasynapse-manifests/ndaConfig --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/ndaconfig.json
 
 # ID of the genomics_sample file to get experiment IDs from
 GENOMICS_SAMPLE_FILE_ID='syn20822548'

--- a/run-live-manifests.sh
+++ b/run-live-manifests.sh
@@ -5,8 +5,8 @@ manifest_type=$(sed -n ${LINE}p /manifest_types.txt)
 
 # Query NDA using the GUID query service for all BSMN collections
 
-aws ssm get-parameters --names synapseconfig-kdaily --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/.synapseConfig
-aws ssm get-parameters --names nda-config --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/ndaconfig.json
+aws ssm get-parameters --names /bsmn-ndasynapse-manifests/synapseConfig --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/.synapseConfig
+aws ssm get-parameters --names /bsmn-ndasynapse-manifests/ndaConfig --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/ndaconfig.json
 
 echo "Running ndasynapse" $(query-nda --version) > /dev/stderr
 

--- a/run-live-manifests.sh
+++ b/run-live-manifests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -o errexit
+
 LINE=$((AWS_BATCH_JOB_ARRAY_INDEX + 1))
 manifest_type=$(sed -n ${LINE}p /manifest_types.txt)
 

--- a/run-original-manifests.sh
+++ b/run-original-manifests.sh
@@ -5,8 +5,8 @@ manifest_type=$(sed -n ${LINE}p /manifest_types_short.txt)
 
 # Query NDA using the original submitted manifests for all BSMN collections
 
-aws ssm get-parameters --names synapseconfig-kdaily --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/.synapseConfig
-aws ssm get-parameters --names nda-config --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/ndaconfig.json
+aws ssm get-parameters --names /bsmn-ndasynapse-manifests/synapseConfig --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/.synapseConfig
+aws ssm get-parameters --names /bsmn-ndasynapse-manifests/ndaConfig --with-decryption --region us-east-1 --output text --query "Parameters[*].{Value:Value}" > /root/ndaconfig.json
 
 echo "Running ndasynapse" $(query-nda --version) > /dev/stderr
 

--- a/run-original-manifests.sh
+++ b/run-original-manifests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -o errexit
+
 LINE=$((AWS_BATCH_JOB_ARRAY_INDEX + 1))
 manifest_type=$(sed -n ${LINE}p /manifest_types_short.txt)
 


### PR DESCRIPTION
Gets secrets from the parameter store based on setup for Sage IT sandbox/scicomp provisioning system. The secrets are at `/bsmn-ndasynapse-manifests/synapseConfig` and `/bsmn-ndasynapse-manifests/ndaConfig`.

This implementation will still work outside of Sage infrastructure, only the location of the keys is changed.